### PR TITLE
修复setIndicatorEqualTabText(true)导致的下划线样式错误

### DIFF
--- a/Tab/src/main/java/cn/we/tablayout/WeTabLayout.java
+++ b/Tab/src/main/java/cn/we/tablayout/WeTabLayout.java
@@ -230,6 +230,9 @@ public class WeTabLayout extends HorizontalScrollView implements ViewPager.OnPag
     }
 
     public void setIndicatorEqualTabText(boolean mIndicatorEqualTabText) {
+        if (mIndicatorEqualTabText) {
+            mIndicatorWidth = 0;
+        }
         this.mIndicatorEqualTabText = mIndicatorEqualTabText;
     }
 


### PR DESCRIPTION
因为在loadAttr中默认的mIndicatorEqualTabText为false，导致mIndicatorWidth会从xml中取值，当从主线程调setIndicatorEqualTabText(true)方法的时候，没有及时清除掉mIndicatorWidth，导致在computeIndicatorRect方法中，计算left和right时产生错误。